### PR TITLE
Update assertion style in TypeScript ESLint config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export default tseslint.config(
       "@typescript-eslint/interface-name-prefix": "off",
       "@typescript-eslint/consistent-type-assertions": [
         "error",
-        { assertionStyle: "angle-bracket" },
+        { assertionStyle: "as" },
       ],
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/explicit-function-return-type": "off",

--- a/test/rules-snapshot.json
+++ b/test/rules-snapshot.json
@@ -2283,7 +2283,7 @@
   "@typescript-eslint/consistent-type-assertions": [
     2,
     {
-      "assertionStyle": "angle-bracket"
+      "assertionStyle": "as"
     }
   ],
   "@typescript-eslint/explicit-function-return-type": [


### PR DESCRIPTION
This pull request updates the TypeScript ESLint configuration to enforce the use of the `as` syntax for type assertions instead of the angle-bracket style. This change is reflected both in the main configuration and in the test snapshot to ensure consistency.

ESLint configuration update:

* Changed the `@typescript-eslint/consistent-type-assertions` rule to require the `as` assertion style instead of the angle-bracket style in `index.js`.

Test snapshot update:

* Updated the corresponding rule in `test/rules-snapshot.json` to match the new `as` assertion style.